### PR TITLE
Call RunNotifier's fireTestFinished() method for failed tests

### DIFF
--- a/src/main/java/be/klak/junit/jasmine/JasmineTestRunner.java
+++ b/src/main/java/be/klak/junit/jasmine/JasmineTestRunner.java
@@ -228,6 +228,7 @@ public class JasmineTestRunner extends Runner {
 			notifier.fireTestFinished(spec.getDescription());
 		} else if (spec.isFailed(rhinoContext)) {
 			notifier.fireTestFailure(spec.getJunitFailure(rhinoContext));
+			notifier.fireTestFinished(spec.getDescription());
 		} else {
 			throw new IllegalStateException("Unexpected spec status received: " + spec);
 		}

--- a/src/test/java/be/klak/junit/jasmine/JasmineFailingSpecsTest.java
+++ b/src/test/java/be/klak/junit/jasmine/JasmineFailingSpecsTest.java
@@ -32,6 +32,7 @@ public class JasmineFailingSpecsTest {
         ArgumentCaptor<Description> descriptionCaptor = ArgumentCaptor.forClass(Description.class);
         verify(notifierMock).fireTestStarted(descriptionCaptor.capture());
         verify(notifierMock).fireTestFailure(failureCaptor.capture());
+        verify(notifierMock).fireTestFinished(descriptionCaptor.capture());
         verifyNoMoreInteractions(notifierMock);
 
         Failure failure = failureCaptor.getValue();
@@ -50,6 +51,7 @@ public class JasmineFailingSpecsTest {
         ArgumentCaptor<Description> descriptionCaptor = ArgumentCaptor.forClass(Description.class);
         verify(notifierMock).fireTestStarted(descriptionCaptor.capture());
         verify(notifierMock).fireTestFailure(failureCaptor.capture());
+        verify(notifierMock).fireTestFinished(descriptionCaptor.capture());
         verifyNoMoreInteractions(notifierMock);
 
         Failure failure = failureCaptor.getValue();


### PR DESCRIPTION
This is to address problems I had using the plugin with a Gradle build.  My test failures were reported fine by the IDEA test runner, however failed tests would be reported as if they had not run by the Gradle test runner (rather than as failures).  This appears to be due to the expectation of balanced calls to the RunNotifier fireTestStarted() and fireTestFinished() methods, even for failed tests (see RunNotifier javadoc).  Hence the changes below.  This tweak fixed the behaviour in Gradle, and IDEA still happily runs the tests. What do you think?